### PR TITLE
Correct lower/higher byte calculation

### DIFF
--- a/src/sfm.cpp
+++ b/src/sfm.cpp
@@ -66,7 +66,7 @@ uint8_t SFM_Module::setRingColor(uint8_t startColor, int8_t endColor, uint16_t p
     @note Please check example for how to register using 3C3R method.
  */
 uint8_t SFM_Module::register_3c3r_1st(uint16_t uid){
-  return _getCmdReturn(0x01, uid >> 8, uid << 8, SFM_DEFAULT_USERROLE);
+  return _getCmdReturn(0x01, (uid >> 8) & 0xFF, uid & 0xFF, SFM_DEFAULT_USERROLE);
 }
 /*!
     @brief 3C3R Register step #2
@@ -100,7 +100,7 @@ uint8_t SFM_Module::register_3c3r_3rd(uint16_t &returnUid){
     @return SFM_ACK_XXX
  */
 uint8_t SFM_Module::deleteUser(uint16_t uid){
-  return _getCmdReturn(0x04, uid >> 8, uid << 8);
+  return _getCmdReturn(0x04, (uid >> 8) & 0xFF, uid & 0xFF);
 }
 /*!
     @brief Delete ALL user(s)
@@ -116,7 +116,7 @@ uint8_t SFM_Module::deleteAllUser(){
     @return SFM_ACK_SUCCESS if matched
  */
 uint8_t SFM_Module::recognition_1v1(uint16_t uid){
-  return _getCmdReturn(0x0B, uid >> 8, uid << 8);
+  return _getCmdReturn(0x0B, (uid >> 8) & 0xFF, uid & 0xFF);
 }
 /*!
     @brief Search the database and find matched uid


### PR DESCRIPTION
With the current code, `SFM_Module::deleteUser()` and `SFM_Module::recognition_1v1()` do not work at all, and `SFM_Module::register_3c3r_1st()` only works without the UID supplied.

According to the SFM-V1.7 datasheet, when doing any operations with the UID, P1 should be the 8 higher bits of the UID, P2 should be the 8 lower bits. Here's an example from the datasheet when deleting a user:
![image](https://user-images.githubusercontent.com/43749899/233857248-62f2d3c7-95c7-443e-98c6-e6e24ca8ec56.png)
The current code doesn't do that. It only bit shifts, but that's not the same as retrieving the higher/lower byte.

This PR fixes the implementation to calculate the higher and lower byte properly. Of course, I tested it, and `deleteUser(uid)`, `recognition_1v1(uid)` and `register_3c3r_1st(uid)` now work flawlessly with this change.

I also added a newline at the end of the file, as that's both required by C/C++ standards and recommended by Git.